### PR TITLE
chore: Remove find_package(). Add alias.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,7 @@ option(BUILD_BENCHMARKS "Build the benchmarks." OFF)
 option(BUILD_EXAMPLES "Build the examples." OFF)
 option(BUILD_TESTS "Build tests." OFF)
 
-find_package(Boost REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(smooth REQUIRED)
 
 # ---------------------------------------------------------------------------------------
 # TARGETS
@@ -19,9 +17,10 @@ find_package(smooth REQUIRED)
 add_library(smooth_feedback INTERFACE)
 target_include_directories(
   smooth_feedback INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                     $<INSTALL_INTERFACE:include>
+                            $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(smooth_feedback INTERFACE Boost::headers smooth::smooth)
+target_link_libraries(smooth_feedback INTERFACE Boost::boost smooth::smooth)
+add_library(smooth::smooth_feedback ALIAS smooth_feedback)
 
 # ---------------------------------------------------------------------------------------
 # INSTALLATION


### PR DESCRIPTION
- Remove find_package() so that linking is done with known packages.
- Add alias.