### PR TITLE
chore: bring back set weights function

### DIFF
--- a/include/smooth/feedback/mpc.hpp
+++ b/include/smooth/feedback/mpc.hpp
@@ -621,6 +621,11 @@ public:
     ocp_.g.R       = weights.R;
     ocp_.g.Q       = weights.Q;
     ocp_.theta.Qtf = weights.Qtf;
+
+    // Run ocp_to_qp steps from constructor of smooth::feedback::MPC to ensure new weights are updated in the QP problem as well.
+    detail::ocp_to_qp_allocate<DT>(qp_, work_, ocp_, mesh_);
+    ocp_to_qp_update<diff::Type::Analytic>(qp_, work_, ocp_, mesh_, prm_.tf, *xdes_, *udes_);
+    qp_solver_.analyze(qp_);    
   }
 
   /**

--- a/include/smooth/feedback/mpc.hpp
+++ b/include/smooth/feedback/mpc.hpp
@@ -622,7 +622,8 @@ public:
     ocp_.g.Q       = weights.Q;
     ocp_.theta.Qtf = weights.Qtf;
 
-    // Run ocp_to_qp steps from constructor of smooth::feedback::MPC to ensure new weights are updated in the QP problem as well.
+    // Run ocp_to_qp steps from constructor of smooth::feedback::MPC to ensure new weights are
+    // updated in the QP problem as well.
     detail::ocp_to_qp_allocate<DT>(qp_, work_, ocp_, mesh_);
     ocp_to_qp_update<diff::Type::Analytic>(qp_, work_, ocp_, mesh_, prm_.tf, *xdes_, *udes_);
     qp_solver_.analyze(qp_);    

--- a/include/smooth/feedback/mpc.hpp
+++ b/include/smooth/feedback/mpc.hpp
@@ -612,6 +612,18 @@ public:
   }
 
   /**
+   * @brief Update MPC weights.
+   * @brief Useful to allow changing MPC weights for different operating conditions without 
+   * losing member variable state such that warmstart_ due to object recreation or reassignment.
+   */
+  inline void set_weights(const MPCWeights<X, U> & weights)
+  {
+    ocp_.g.R       = weights.R;
+    ocp_.g.Q       = weights.Q;
+    ocp_.theta.Qtf = weights.Qtf;
+  }
+
+  /**
    * @brief Reset initial guess for next iteration to zero.
    */
   inline void reset_warmstart() { warmstart_ = {}; }


### PR DESCRIPTION
Bring back the set_weights() function so that MPC weights can be changed at different operating conditions (i) without needing to recreate/reassign a new MPC object (ii) retaining the state of member variables such as MPC::warmstart_ due to the non recreation/reassignment of the MPC object

This time however, ocp_to_qp steps from MPC's constructor are also called in set_weights() to ensure the new weights actually get carried over/updated in the QP problem to be solved. 